### PR TITLE
Convert initialize to a true package level init function

### DIFF
--- a/jcrypt/jcrypt.go
+++ b/jcrypt/jcrypt.go
@@ -44,7 +44,7 @@ var alphaNum map[rune]int
 
 var extra map[rune]int
 
-func initialize() {
+func init() {
 	numAlpha = make(map[int]rune)
 	alphaNum = make(map[rune]int)
 	extra = make(map[rune]int)
@@ -62,7 +62,6 @@ func initialize() {
 }
 
 func Encrypt(password string, salt rune) string {
-	initialize()
 
 	rand := randc(extra[salt])
 	prev := salt


### PR DESCRIPTION
This allows concurrent usage of this library, by utilizing the Go native init function. This function is run only once during package import. Currently, the code will causes panics with concurrent map writes, if used concurrently e.g. in a web server